### PR TITLE
Escape $ in CTA regex

### DIFF
--- a/lib/extensions/call-to-action.js
+++ b/lib/extensions/call-to-action.js
@@ -4,7 +4,7 @@ module.exports = {
   name: 'govspeak-call-to-action',
   level: 'block',
   start (src) {
-    return src.match(/$CTA(?!\s)/)?.index
+    return src.match(/\$CTA(?!\s)/)?.index
   },
   tokenizer: function (src) {
     return blockTokenizer.bind(this)(src, 'govspeak-call-to-action', '$CTA')


### PR DESCRIPTION
Tiniest PR to escape the $ in the regex for the call to action extension