### PR TITLE
Use recommended extension export

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ npm install @x-govuk/marked-govspeak
 
 ## Usage
 
-Import `govspeak` and and add these extensions to marked with `marked.use()`:
-
 ```js
 import { marked } from "marked";
 import govspeak from "@x-govuk/marked-govspeak";
 
-marked.use({ extensions: govspeak });
+marked.use(govspeak());
 ```
 
 When you call `marked`, the generated HTML will include the classes to style the Govspeak Markdown extensions. For example:
@@ -61,7 +59,12 @@ The class names used also differ, each prefixed with `govspeak-`. Therefore a `g
 If you wish to generate class names that match those from the Govspeak Ruby gem, you can pass the `govspeakGemCompatibility` option to marked. For example:
 
 ```js
-marked.setOptions({ govspeakGemCompatibility: true });
+import { marked } from "marked";
+import govspeak from "@x-govuk/marked-govspeak";
+
+marked.use(govspeak({
+  govspeakGemCompatibility: true
+}));
 
 marked("%This is a warning callout%");
 ```

--- a/index.js
+++ b/index.js
@@ -1,15 +1,25 @@
-module.exports = [
-  require('./lib/extensions/address'),
-  require('./lib/extensions/button'),
-  require('./lib/extensions/call-to-action'),
-  require('./lib/extensions/contact'),
-  require('./lib/extensions/form-download'),
-  require('./lib/extensions/example'),
-  require('./lib/extensions/information'),
-  require('./lib/extensions/information-callout'),
-  require('./lib/extensions/place'),
-  require('./lib/extensions/stat-headline'),
-  require('./lib/extensions/steps').steps,
-  require('./lib/extensions/steps').step,
-  require('./lib/extensions/warning-callout')
-]
+/**
+ * Render Govspeak markup.
+ *
+ * @param {object} [options] Options for the extension
+ * @returns {object} A MarkedExtension to be passed to `marked.use()`
+ */
+module.exports = function (options = {}) {
+  return {
+    extensions: [
+      require('./lib/extensions/address')(options),
+      require('./lib/extensions/button')(options),
+      require('./lib/extensions/call-to-action')(options),
+      require('./lib/extensions/contact')(options),
+      require('./lib/extensions/form-download')(options),
+      require('./lib/extensions/example')(options),
+      require('./lib/extensions/information')(options),
+      require('./lib/extensions/information-callout')(options),
+      require('./lib/extensions/place')(options),
+      require('./lib/extensions/stat-headline')(options),
+      require('./lib/extensions/steps').steps(options),
+      require('./lib/extensions/steps').step(options),
+      require('./lib/extensions/warning-callout')(options)
+    ]
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "module": "commonjs",
+    "target": "es2022"
+  }
+}

--- a/lib/block-tokenizer.js
+++ b/lib/block-tokenizer.js
@@ -1,12 +1,13 @@
 /**
  * Parse a Govspeak Markdown block
+ * @param {import('marked').Lexer} lexer Marked lexer
  * @param {string} src Source text to be parsed
  * @param {string} name Extension name, i.e. `govspeak-example`
  * @param {string} open Opening tag, i.e. $E
  * @param {string} [close] Closing tag, i.e. $E
  * @returns {object} Tokens
  */
-module.exports = function (src, name, open, close) {
+module.exports = function (lexer, src, name, open, close) {
   if (!src.startsWith(`${open}\n`)) {
     return
   }
@@ -22,7 +23,7 @@ module.exports = function (src, name, open, close) {
       text: src.slice(closeLength, nextIndex).trim(),
       tokens: []
     }
-    this.lexer.blockTokens(token.text, token.tokens)
+    lexer.blockTokens(token.text, token.tokens)
     return token
   }
 }

--- a/lib/class-generator.js
+++ b/lib/class-generator.js
@@ -4,10 +4,11 @@ const gemCompatibleClassNames = require('./class-names').compatible
 /**
  * Get class name for given component
  * @param {string} component - Component name, i.e. 'button'
+ * @param {object} [options] - Extension options
  * @returns {string} Class name, i.e. 'govuk-button'
  */
-module.exports = function (component) {
-  const classNames = this.parser.options.govspeakGemCompatibility
+module.exports = function (component, options = {}) {
+  const classNames = options.govspeakGemCompatibility
     ? gemCompatibleClassNames
     : defaultClassNames
 

--- a/lib/extensions/address.js
+++ b/lib/extensions/address.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-address',
-  level: 'block',
-  start (src) {
-    return src.match(/\$A\n(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-address', '$A')
-  },
-  renderer (token) {
-    return `<address class="${classGenerator.bind(this)('address')}">
-  ${this.parser.parse(token.tokens)}
-</address>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-address',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$A\n(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-address', '$A')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('address', options)
+      return `<address class="${className}">\n  ${this.parser.parse(tokens)}\n</address>`
+    }
   }
 }

--- a/lib/extensions/button.js
+++ b/lib/extensions/button.js
@@ -1,43 +1,51 @@
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-button',
-  level: 'inline',
-  start (src) {
-    return src.match(/{button(?!\s)/)?.index
-  },
-  tokenizer (src) {
-    if (!src.startsWith('{button')) {
-      return
-    }
+module.exports = function (options) {
+  return {
+    name: 'govspeak-button',
 
-    let isStartButton = false
-    let openLength = 8
-    const closeLength = 9
+    level: 'inline',
 
-    if (src.startsWith('{button start}')) {
-      isStartButton = true
-      openLength = 14
-    }
+    start (src) {
+      return src.match(/{button(?!\s)/)?.index
+    },
 
-    const nextIndex = src.indexOf('{/button}', 2)
-    if (nextIndex !== -1) {
-      const token = {
-        type: 'govspeak-button',
-        raw: src.slice(0, nextIndex + closeLength),
-        text: src.slice(openLength, nextIndex).trim(),
-        isStartButton,
-        tokens: []
+    tokenizer (src) {
+      if (!src.startsWith('{button')) {
+        return
       }
-      this.lexer.inlineTokens(token.text, token.tokens)
-      return token
-    }
-  },
-  renderer (token) {
-    if (token.isStartButton) {
-      return `<a class="${classGenerator.bind(this)('button--start')}" href="${token.tokens[0].href}" role="button">${token.tokens[0].text}<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/></svg></a>`
-    }
 
-    return `<a class="${classGenerator.bind(this)('button')}" href="${token.tokens[0].href}" role="button">${token.tokens[0].text}</a>`
+      let isStartButton = false
+      let openLength = 8
+      const closeLength = 9
+
+      if (src.startsWith('{button start}')) {
+        isStartButton = true
+        openLength = 14
+      }
+
+      const nextIndex = src.indexOf('{/button}', 2)
+      if (nextIndex !== -1) {
+        const token = {
+          type: 'govspeak-button',
+          raw: src.slice(0, nextIndex + closeLength),
+          text: src.slice(openLength, nextIndex).trim(),
+          isStartButton,
+          tokens: []
+        }
+        this.lexer.inlineTokens(token.text, token.tokens)
+        return token
+      }
+    },
+
+    renderer ({ isStartButton, tokens }) {
+      if (isStartButton) {
+        const className = classGenerator('button--start', options)
+        return `<a class="${className}" href="${tokens[0].href}" role="button">${tokens[0].text}<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/></svg></a>`
+      }
+
+      const className = classGenerator('button', options)
+      return `<a class="${className}" href="${tokens[0].href}" role="button">${tokens[0].text}</a>`
+    }
   }
 }

--- a/lib/extensions/call-to-action.js
+++ b/lib/extensions/call-to-action.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-call-to-action',
-  level: 'block',
-  start (src) {
-    return src.match(/\$CTA(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-call-to-action', '$CTA')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('call-to-action')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-call-to-action',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$CTA(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-call-to-action', '$CTA')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('call-to-action', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/contact.js
+++ b/lib/extensions/contact.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-contact',
-  level: 'block',
-  start (src) {
-    return src.match(/\$C\n(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-contact', '$C')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('contact')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-contact',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$C\n(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-contact', '$C')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('contact', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/example.js
+++ b/lib/extensions/example.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-example',
-  level: 'block',
-  start (src) {
-    return src.match(/\$E\n(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-example', '$E')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('example')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-example',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$E\n(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-example', '$E')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('example', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/form-download.js
+++ b/lib/extensions/form-download.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-form-download',
-  level: 'block',
-  start (src) {
-    return src.match(/\$D\n(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-form-download', '$D')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('form-download')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-form-download',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$D\n(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-form-download', '$D')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('form-download', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/information-callout.js
+++ b/lib/extensions/information-callout.js
@@ -1,28 +1,33 @@
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-information-callout',
-  level: 'block',
-  start (src) {
-    return src.match(/\^(?!\s)/)?.index
-  },
-  tokenizer (src) {
-    if (!src.startsWith('^')) {
-      return
-    }
+module.exports = function (options) {
+  return {
+    name: 'govspeak-information-callout',
 
-    const nextIndex = src.indexOf('^', 2)
-    if (nextIndex !== -1) {
-      return {
-        type: 'govspeak-information-callout',
-        raw: src.slice(0, nextIndex + 2),
-        text: this.lexer.inlineTokens(src.slice(1, nextIndex))
+    level: 'block',
+
+    start (src) {
+      return src.match(/\^(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      if (!src.startsWith('^')) {
+        return
       }
+
+      const nextIndex = src.indexOf('^', 2)
+      if (nextIndex !== -1) {
+        return {
+          type: 'govspeak-information-callout',
+          raw: src.slice(0, nextIndex + 2),
+          text: this.lexer.inlineTokens(src.slice(1, nextIndex))
+        }
+      }
+    },
+
+    renderer ({ text }) {
+      const className = classGenerator('information-callout', options)
+      return `<div class="${className}" role="note" aria-label="Information">\n  <p>${this.parser.parseInline(text)}</p>\n</div>`
     }
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('information-callout')}" role="note" aria-label="Information">
-  <p>${this.parser.parseInline(token.text)}</p>
-</div>`
   }
 }

--- a/lib/extensions/information.js
+++ b/lib/extensions/information.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-information',
-  level: 'block',
-  start (src) {
-    return src.match(/\$I\n(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-information', '$I')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('information')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-information',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$I\n(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-information', '$I')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('information', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/place.js
+++ b/lib/extensions/place.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-place',
-  level: 'block',
-  start (src) {
-    return src.match(/\$C\n(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-place', '$P')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('place')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-place',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/\$C\n(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-place', '$P')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('place', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/stat-headline.js
+++ b/lib/extensions/stat-headline.js
@@ -1,18 +1,23 @@
 const blockTokenizer = require('../block-tokenizer')
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-stat-headline',
-  level: 'block',
-  start (src) {
-    return src.match(/{stat(?!\s)/)?.index
-  },
-  tokenizer: function (src) {
-    return blockTokenizer.bind(this)(src, 'govspeak-stat-headline', '{stat-headline}', '{/stat-headline}')
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('stat-headline')}">
-  ${this.parser.parse(token.tokens)}
-</div>`
+module.exports = function (options) {
+  return {
+    name: 'govspeak-stat-headline',
+
+    level: 'block',
+
+    start (src) {
+      return src.match(/{stat(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      return blockTokenizer(this.lexer, src, 'govspeak-stat-headline', '{stat-headline}', '{/stat-headline}')
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('stat-headline', options)
+      return `<div class="${className}">\n  ${this.parser.parse(tokens)}\n</div>`
+    }
   }
 }

--- a/lib/extensions/steps.js
+++ b/lib/extensions/steps.js
@@ -1,53 +1,67 @@
 const classGenerator = require('../class-generator.js')
 
-module.exports.steps = {
-  name: 'govspeak-steps',
-  level: 'block',
-  start (src) {
-    return src.match(/\s*(?:s\d+\.\s.*(?:\n|$))+/)?.index
-  },
-  tokenizer (src) {
-    const rule = /^\s*(?:s\d+\.\s.*(?:\n|$))+/
-    const match = rule.exec(src)
-    if (match) {
-      const token = {
-        type: 'govspeak-steps',
-        raw: match[0],
-        text: match[0].trim(),
-        tokens: []
-      }
-      this.lexer.inline(token.text, token.tokens)
+module.exports.steps = function (options) {
+  return {
+    name: 'govspeak-steps',
 
-      return token
+    level: 'block',
+
+    start (src) {
+      return src.match(/\s*(?:s\d+\.\s.*(?:\n|$))+/)?.index
+    },
+
+    tokenizer (src) {
+      const rule = /^\s*(?:s\d+\.\s.*(?:\n|$))+/
+      const match = rule.exec(src)
+      if (match) {
+        const token = {
+          type: 'govspeak-steps',
+          raw: match[0],
+          text: match[0].trim(),
+          tokens: []
+        }
+        this.lexer.inline(token.text, token.tokens)
+
+        return token
+      }
+    },
+
+    renderer ({ tokens }) {
+      const className = classGenerator('steps', options)
+      return `<ol class="${className}">${this.parser.parseInline(tokens)}\n</ol>`
     }
-  },
-  renderer (token) {
-    return `<ol class="${classGenerator.bind(this)('steps')}">${this.parser.parseInline(token.tokens)}\n</ol>`
   }
 }
 
-module.exports.step = {
-  name: 'govspeak-step',
-  level: 'inline',
-  start (src) {
-    return src.match(/s(\d+)\./)?.index
-  },
-  tokenizer (src) {
-    const rule = /s(\d+)\.\s(.*)(?:\n|$)/
-    const match = rule.exec(src)
+module.exports.step = function (_options) {
+  return {
+    name: 'govspeak-step',
 
-    if (match) {
-      const token = {
-        type: 'govspeak-step',
-        raw: match[0],
-        li: this.lexer.inlineTokens(match[2].trim())
+    level: 'inline',
+
+    start (src) {
+      return src.match(/s(\d+)\./)?.index
+    },
+
+    tokenizer (src) {
+      const rule = /s(\d+)\.\s(.*)(?:\n|$)/
+      const match = rule.exec(src)
+
+      if (match) {
+        const token = {
+          type: 'govspeak-step',
+          raw: match[0],
+          li: this.lexer.inlineTokens(match[2].trim())
+        }
+
+        return token
       }
+    },
 
-      return token
-    }
-  },
-  renderer (token) {
-    return `\n  <li>${this.parser.parseInline(token.li)}</li>`
-  },
-  childTokens: ['li']
+    renderer ({ li }) {
+      return `\n  <li>${this.parser.parseInline(li)}</li>`
+    },
+
+    childTokens: ['li']
+  }
 }

--- a/lib/extensions/warning-callout.js
+++ b/lib/extensions/warning-callout.js
@@ -1,28 +1,33 @@
 const classGenerator = require('../class-generator.js')
 
-module.exports = {
-  name: 'govspeak-warning-callout',
-  level: 'block',
-  start (src) {
-    return src.match(/%(?!\s)/)?.index
-  },
-  tokenizer (src) {
-    if (!src.startsWith('%')) {
-      return
-    }
+module.exports = function (options) {
+  return {
+    name: 'govspeak-warning-callout',
 
-    const nextIndex = src.indexOf('%', 2)
-    if (nextIndex !== -1) {
-      return {
-        type: 'govspeak-warning-callout',
-        raw: src.slice(0, nextIndex + 2),
-        text: this.lexer.inlineTokens(src.slice(1, nextIndex))
+    level: 'block',
+
+    start (src) {
+      return src.match(/%(?!\s)/)?.index
+    },
+
+    tokenizer (src) {
+      if (!src.startsWith('%')) {
+        return
       }
+
+      const nextIndex = src.indexOf('%', 2)
+      if (nextIndex !== -1) {
+        return {
+          type: 'govspeak-warning-callout',
+          raw: src.slice(0, nextIndex + 2),
+          text: this.lexer.inlineTokens(src.slice(1, nextIndex))
+        }
+      }
+    },
+
+    renderer ({ text }) {
+      const className = classGenerator('warning-callout', options)
+      return `<div class="${className}" role="note" aria-label="Warning">\n  <p>${this.parser.parseInline(text)}</p>\n</div>`
     }
-  },
-  renderer (token) {
-    return `<div class="${classGenerator.bind(this)('warning-callout')}" role="note" aria-label="Warning">
-  <p>${this.parser.parseInline(token.text)}</p>
-</div>`
   }
 }

--- a/test/compatibility.js
+++ b/test/compatibility.js
@@ -4,8 +4,9 @@ const { marked } = require('marked')
 const govspeak = require('../index.js')
 
 describe('Govspeak with RubyGem compatibility', () => {
-  marked.setOptions({ govspeakGemCompatibility: true })
-  marked.use({ extensions: govspeak })
+  marked.use(govspeak({
+    govspeakGemCompatibility: true
+  }))
 
   it('Renders address', () => {
     assert.equal(

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const { marked } = require('marked')
 const govspeak = require('../index.js')
 
 describe('Govspeak', () => {
-  marked.use({ extensions: govspeak })
+  marked.use(govspeak())
 
   it('Renders address', () => {
     assert.equal(


### PR DESCRIPTION
Use the export format [recommended by `marked`](https://github.com/markedjs/marked-extension-template/blob/main/src/index.js), which provides an `extensions` options value.

This means that:

```js
marked.use({ extensions: govspeak })
```

becomes…

```js
marked.use(govspeak())
```

It also means options are provided to the extension itself, rather than polluting `marked`’s own options object, i.e.:

```js
marked.use(govspeak({
  govspeakGemCompatibility: true
}))
```